### PR TITLE
Wrap table cells with per-cell Link when row is linkable and adjust padding; remove experience link offset

### DIFF
--- a/src/components/blocks/table.tsx
+++ b/src/components/blocks/table.tsx
@@ -168,32 +168,43 @@ export function Table<Row>({
                       )}
                       key={getRowKey(row, index)}
                     >
-                      {columns.map((column, columnIndex) => (
-                        <td
-                          className={cn(
-                            columnIndex > 0 && "border-l border-[#30302f]",
-                            "px-2 py-1.5",
-                            typeof column.cellClassName === "function"
-                              ? column.cellClassName(row, index)
-                              : column.cellClassName,
-                          )}
-                          key={column.id}
-                        >
-                          {columnIndex === 0 && rowLink ? (
-                            <Link
-                              aria-label={rowLink.ariaLabel}
-                              className={cn(
-                                "absolute inset-y-0 right-0 left-0 z-10 cursor-pointer focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:outline-none",
-                                rowLink.className,
-                              )}
-                              href={rowLink.href}
-                              rel={rowLink.rel}
-                              target={rowLink.target}
-                            />
-                          ) : null}
-                          {column.render(row)}
-                        </td>
-                      ))}
+                      {columns.map((column, columnIndex) => {
+                        const cellContent = column.render(row);
+
+                        return (
+                          <td
+                            className={cn(
+                              columnIndex > 0 && "border-l border-[#30302f]",
+                              rowLink ? "p-0" : "px-2 py-1.5",
+                              typeof column.cellClassName === "function"
+                                ? column.cellClassName(row, index)
+                                : column.cellClassName,
+                            )}
+                            key={column.id}
+                          >
+                            {rowLink ? (
+                              <Link
+                                aria-label={
+                                  columnIndex === 0
+                                    ? rowLink.ariaLabel
+                                    : undefined
+                                }
+                                className={cn(
+                                  "block h-full px-2 py-1.5 focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:outline-none",
+                                  rowLink.className,
+                                )}
+                                href={rowLink.href}
+                                rel={rowLink.rel}
+                                target={rowLink.target}
+                              >
+                                {cellContent}
+                              </Link>
+                            ) : (
+                              cellContent
+                            )}
+                          </td>
+                        );
+                      })}
                     </tr>
                   );
                 })

--- a/src/components/home/experience-table.tsx
+++ b/src/components/home/experience-table.tsx
@@ -29,7 +29,7 @@ const experienceColumns = [
     icon: Briefcase,
     headerClassName: "w-[210px]",
     render: (data) => (
-      <span className="relative z-0 flex items-center gap-2">
+      <span className="flex items-center gap-2">
         <span
           className={`relative h-6 w-6 shrink-0 overflow-hidden rounded-sm ${
             "transparent" in data && data.transparent ? "bg-white" : ""
@@ -97,7 +97,6 @@ export function ExperienceTable() {
       getRowLink={(data) => ({
         href: data.link,
         ariaLabel: `${data.name} website`,
-        className: "right-[90px]",
         rel: "noreferrer",
         target: "_blank",
       })}


### PR DESCRIPTION
### Motivation
- Ensure rows that are linkable have an accessible, full-height clickable area without relying on an absolutely positioned overlay. 
- Fix visual/layout issues caused by the previous absolute link overlay and a hard-coded right offset in the experience table. 

### Description
- Updated `Table` to wrap cell content in a `Link` when `getRowLink` is provided, moving padding into the `Link` and using `p-0` on the `td` to avoid double padding. 
- Preserved `aria-label` only on the first column's link and added focus-visible styles to the per-cell `Link` to maintain keyboard accessibility. 
- Replaced the previous absolute overlay approach with a block-level `Link` that fills each cell so the entire cell becomes clickable. 
- In `experience-table`, removed the `relative z-0` wrapper class from the company cell and removed the `right-[90px]` offset from the row link configuration. 

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which succeeded. 
- Ran ESLint, which passed without new errors. 
- Performed a local `next build` and verified the application builds successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4766f583bc832d90fe3b2a212b0a8a)